### PR TITLE
Handle wrong opensubtitles api key #24

### DIFF
--- a/subtitles_api/constants.py
+++ b/subtitles_api/constants.py
@@ -1,6 +1,7 @@
 class SubtitlesConstants:
     DL_URL = "https://api.opensubtitles.com/api/v1/download/"
     SEARCH_URL = "https://api.opensubtitles.com/api/v1/subtitles/"
+    SUBS_FORMATS_URL = "https://api.opensubtitles.com/api/v1/infos/formats"
     FILE_TYPES = ('.m1v', '.mpeg', '.mov', '.qt', '.mpa', '.mpg', '.mpe', '.avi', '.movie', '.mp4')
     OPEN_SUBTITLES_ENDPOINT = "https://api.opensubtitles.com/api/v1/subtitles"
     LANGUAGES_CODES = {

--- a/subtitles_api/tests/subtitles_tests.py
+++ b/subtitles_api/tests/subtitles_tests.py
@@ -10,7 +10,13 @@ class SubtitlesTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         if not cls.perform_initial_setup():
             cls.skipTest(cls, "Initial setup failed. Aborting remaining tests in .")
-        
+
+    def setUp(self) -> None:
+        print() # Add a line feed before each test method
+
+    def tearDown(self) -> None:
+        print() # Add a line feed after each test method
+
     @classmethod
     def perform_initial_setup(cls):
         
@@ -43,33 +49,42 @@ class SubtitlesTests(unittest.TestCase):
         wrong_api_keys = [None, 10, ""]
         for i, wrong_api_key in enumerate(wrong_api_keys):
             with self.subTest(test_number=f"Test # {i}"):
+                print(f"Running {self._testMethodName} subTest #{i+1}")
                 with self.assertRaises(ValueError):
                     Subtitles(wrong_api_key, log_folder=self.config_obj.logs_folder)
 
     def test_download_subs_right_dir(self):
 
-        file_id = self.subs_obj.search_subs(
-            lang=SubtitlesTestConstants.LANG, 
-            title=SubtitlesTestConstants.TITLE, 
-            year=SubtitlesTestConstants.YEAR, 
-            resolution=SubtitlesTestConstants.RESOLUTION, 
-            quality=SubtitlesTestConstants.QUALITY, 
-            codec=SubtitlesTestConstants.CODEC, 
-            group=SubtitlesTestConstants.GROUP,
-            excess=SubtitlesTestConstants.EXCESS
-        )
-        
+        file_id = None
+
+        try:
+            file_id = self.subs_obj.search_subs(
+                lang=SubtitlesTestConstants.LANG, 
+                title=SubtitlesTestConstants.TITLE, 
+                year=SubtitlesTestConstants.YEAR, 
+                resolution=SubtitlesTestConstants.RESOLUTION, 
+                quality=SubtitlesTestConstants.QUALITY, 
+                codec=SubtitlesTestConstants.CODEC, 
+                group=SubtitlesTestConstants.GROUP,
+                excess=SubtitlesTestConstants.EXCESS
+            )
+        except Exception as error:
+            self.fail(f'{self._testMethodName} failed to search subs. Exception: {error}')
+
         folder_path = self.config_obj.download_folder
         file_name = f"{SubtitlesTestConstants.MOVIE_FILE_NAME}-{SubtitlesTestConstants.LANG}.srt"
         file_path = os.path.join(folder_path, file_name)
 
-        self.subs_obj.download_subs(
-            SubtitlesTestConstants.LANG, 
-            SubtitlesTestConstants.MOVIE_FILE_NAME, 
-            SubtitlesTestConstants.MOVIE_FILE_NAME, 
-            file_id, 
-            folder_path
-        )
+        try:
+            self.subs_obj.download_subs(
+                SubtitlesTestConstants.LANG, 
+                SubtitlesTestConstants.MOVIE_FILE_NAME, 
+                SubtitlesTestConstants.MOVIE_FILE_NAME, 
+                file_id, 
+                folder_path
+            )
+        except Exception as error:
+            self.fail(f'{self._testMethodName} failed to download subs. Exception: {error}')
 
         self.assertTrue(os.path.exists(file_path), f"File '{file_name}' does not exist in folder '{folder_path}'.")
 


### PR DESCRIPTION
1) Add new method for checking api_key isn't empty and not str type.
2) Raise exceptions for post/get that might fail due to wrong api_key or other.

Handle wrong opensubtitles api key #24